### PR TITLE
Add Huly.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ monthly, Small (1 - 10 users)</b>
   1. [Redbooth](https://redbooth.com/pricing) - Flexible Project Management software that scales with your team. <b>Starting from $9 /user/month</b>
   1. [Bitrix24](https://www.bitrix24.com) - Stunningly beautiful websites and landing pages, ready to help you sell your products and services in minutes. <b>Free for 12 users</b>
   1. [Lavagna.io](https://lavagna.io/) - Lavagna is an open-source issue/project management tool designed for small teams. <b>Open source, Self install</b>
-    
+  1. [Huly.io](https://huly.io) - Huly.io is Open-source all-in-one project management platform combining features of Linear, Jira, Slack, and Notion. Offers task management, sprint planning, collaborative docs, team chat, and video conferencing. <b>Open source, Self install</b>
 
 
 ## Free Template


### PR DESCRIPTION
Added a link to huly.io project. [Huly.io](https://huly.io/) — Open-source all-in-one project management platform combining features of Linear, Jira, Slack, and Notion. Offers task management, sprint planning, collaborative docs, team chat, and video conferencing. **Open-source, Self install**