### PR TITLE
Add git-native-issue to Source Code Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ monthly, Small (1 - 10 users)</b>
 - [Launchpad](https://launchpad.net/)
 - [Sourceforge](https://sourceforge.net/)
 - [Gitea](https://gitea.io/en-us/)
+- [git-native-issue](https://github.com/remenoscodes/git-native-issue) - Distributed issue tracking embedded in Git. Track bugs and tasks as native Git objects, sync via push/pull, no server required. Free. Open Source.
 
 
 


### PR DESCRIPTION
Adds [git-native-issue](https://github.com/remenoscodes/git-native-issue) to the **Source Code Management (SCM)** section.

**git-native-issue** brings issue tracking directly into Git:
- Issues stored as native Git objects — no external database
- Sync via `git push`/`git pull` — fully offline-first
- Bridges to GitHub/GitLab for team collaboration
- Free, open source (GPL-2.0), POSIX shell

It fills a gap in the SCM section by adding a decentralized issue tracker that works alongside Git hosting platforms.